### PR TITLE
Fix undefined intdiv usage

### DIFF
--- a/web/steamopenid.php
+++ b/web/steamopenid.php
@@ -94,7 +94,7 @@ function sb_big_div2($a)
     $len = strlen($a);
     for ($i = 0; $i < $len; $i++) {
         $num = $carry * 10 + (int)$a[$i];
-        $result .= intdiv($num, 2);
+        $result .= (int)($num / 2);
         $carry = $num % 2;
     }
     $result = ltrim($result, '0');


### PR DESCRIPTION
## Summary
- avoid calling PHP 7 intdiv by using manual integer division

## Testing
- `php -l web/steamopenid.php`

------
https://chatgpt.com/codex/tasks/task_e_6856442341c88327bfd9d1300d0c47e2