### PR TITLE
Fix Steam login redirect

### DIFF
--- a/web/init.php
+++ b/web/init.php
@@ -95,8 +95,8 @@ if(!defined("DEVELOPER_MODE") && !defined("IS_UPDATE") && file_exists(ROOT."/upd
 // ---------------------------------------------------
 define('SB_GIT', true);
 if(!defined('SB_VERSION')){
-	define('SB_VERSION', '1.5.5-dev');
-	define('SB_GITRev', '$Git: 377 $');
+        define('SB_VERSION', '1.5.5-dev');
+        define('SB_GITRev', '$Git: 379 $');
 }
 define('LOGIN_COOKIE_LIFETIME', (60*60*24*7)*2);
 define('COOKIE_PATH', '/');

--- a/web/steamopenid.php
+++ b/web/steamopenid.php
@@ -131,7 +131,8 @@ function steamOauth() {
 
 
 if(isset($_COOKIE['aid'])){
-    header("Location: " .SB_URL);
+    header("Location: " .SB_URL . "/index.php?p=admin");
+    exit;
 }
 
 $data = steamOauth();
@@ -147,17 +148,22 @@ if($data !== false){
         list($aid, $password) = $resultado->fetch_row();
         global $userbank;
         if (empty($password) || $password == $userbank->encrypt_password('')) {
+            $mysqli->close();
             header("Location: " .SB_URL ."/index.php?p=login&m=empty_pwd");
-            die;
-        } else {
-            setcookie("aid", $aid, time() + LOGIN_COOKIE_LIFETIME);
-            setcookie("password", $password, time() + LOGIN_COOKIE_LIFETIME);
+            exit;
         }
+
+        setcookie("aid", $aid, time() + LOGIN_COOKIE_LIFETIME, "/");
+        setcookie("password", $password, time() + LOGIN_COOKIE_LIFETIME, "/");
+        $mysqli->close();
+        header("Location: " .SB_URL ."/index.php?p=admin");
+        exit;
     }
 
     $mysqli->close();
+    header("Location: " .SB_URL ."/index.php?p=login");
+    exit;
 }else{
     header("Location: " .SB_URL ."/index.php?p=login");
+    exit;
 }
-
-header("Location: " .SB_URL);


### PR DESCRIPTION
## Summary
- fix Steam login redirect to go to admin page and set cookies for `/`
- bump SB_GITRev to 379

## Testing
- `php -l web/steamopenid.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685653317e788327afccca4f2642377f