### PR TITLE
Fix logout cookie path

### DIFF
--- a/web/includes/CUserManager.php
+++ b/web/includes/CUserManager.php
@@ -203,15 +203,15 @@ class CUserManager
 	        if($save)
 	        {
 	            //Sets cookies
-	            setcookie("aid", $aid, time()+LOGIN_COOKIE_LIFETIME);
-	            setcookie("password", $this->encrypt_password($password), time()+LOGIN_COOKIE_LIFETIME);
-	            setcookie("user", isset($_SESSION['user']['user'])?$_SESSION['user']['user']:null, time()+LOGIN_COOKIE_LIFETIME);
+                    setcookie("aid", $aid, time() + LOGIN_COOKIE_LIFETIME, COOKIE_PATH, COOKIE_DOMAIN, COOKIE_SECURE);
+                    setcookie("password", $this->encrypt_password($password), time() + LOGIN_COOKIE_LIFETIME, COOKIE_PATH, COOKIE_DOMAIN, COOKIE_SECURE);
+                    setcookie("user", isset($_SESSION['user']['user']) ? $_SESSION['user']['user'] : null, time() + LOGIN_COOKIE_LIFETIME, COOKIE_PATH, COOKIE_DOMAIN, COOKIE_SECURE);
 	        }
 	        else 
 	        {
-	        	setcookie("aid", $aid);
-	            setcookie("password", $this->encrypt_password($password));
-	            setcookie("user", $_SESSION['user']['user']);
+                        setcookie("aid", $aid, 0, COOKIE_PATH, COOKIE_DOMAIN, COOKIE_SECURE);
+                    setcookie("password", $this->encrypt_password($password), 0, COOKIE_PATH, COOKIE_DOMAIN, COOKIE_SECURE);
+                    setcookie("user", $_SESSION['user']['user'], 0, COOKIE_PATH, COOKIE_DOMAIN, COOKIE_SECURE);
 	        }
 	        return true;
 	    }

--- a/web/includes/user-functions.php
+++ b/web/includes/user-functions.php
@@ -62,11 +62,11 @@ function generate_salt($length=5)
  * @return true.
  */
 function logout() {
-	setcookie('aid', '', time()-86400);
-	setcookie('password', '', time()-86400);
-	$_SESSION = array();
-	session_destroy();
-	return true;
+        setcookie('aid', '', time() - 86400, COOKIE_PATH, COOKIE_DOMAIN, COOKIE_SECURE);
+        setcookie('password', '', time() - 86400, COOKIE_PATH, COOKIE_DOMAIN, COOKIE_SECURE);
+        $_SESSION = array();
+        session_destroy();
+        return true;
 }
 
 /**

--- a/web/steamopenid.php
+++ b/web/steamopenid.php
@@ -153,8 +153,8 @@ if($data !== false){
             exit;
         }
 
-        setcookie("aid", $aid, time() + LOGIN_COOKIE_LIFETIME, "/");
-        setcookie("password", $password, time() + LOGIN_COOKIE_LIFETIME, "/");
+        setcookie("aid", $aid, time() + LOGIN_COOKIE_LIFETIME, COOKIE_PATH, COOKIE_DOMAIN, COOKIE_SECURE);
+        setcookie("password", $password, time() + LOGIN_COOKIE_LIFETIME, COOKIE_PATH, COOKIE_DOMAIN, COOKIE_SECURE);
         $mysqli->close();
         header("Location: " .SB_URL ."/index.php?p=admin");
         exit;


### PR DESCRIPTION
## Summary
- ensure logout clears cookies with the same path as login
- use constant cookie path when logging in or logging out

## Testing
- `php -l web/includes/user-functions.php`
- `php -l web/includes/CUserManager.php`
- `php -l web/steamopenid.php`


------
https://chatgpt.com/codex/tasks/task_e_685659cb68e483278ce40f8ccf78f472